### PR TITLE
Make the installed package relocalisable

### DIFF
--- a/src/integration/malt-passwd.sh.in
+++ b/src/integration/malt-passwd.sh.in
@@ -7,6 +7,8 @@
 #            LICENSE  : CeCILL-C                     #
 ######################################################
 
+MALT_ROOT="$(cd $(dirname $0)/.. && pwd)"
+
 ######################################################
 NODE=""
 detectNodeJS()
@@ -53,9 +55,9 @@ done
 
 #call node on main script
 if [ -z "$HAVE_OPT" ]; then
-	"$NODE" "@CMAKE_INSTALL_PREFIX@/share/malt/webview/node_modules/.bin/htpasswd" "-c" "$HOME/.malt/passwd" "$@" || exit 1
+	"$NODE" "${MALT_ROOT}/share/malt/webview/node_modules/.bin/htpasswd" "-c" "$HOME/.malt/passwd" "$@" || exit 1
 else
-	"$NODE" "@CMAKE_INSTALL_PREFIX@/share/malt/webview/node_modules/.bin/htpasswd" "$@" || exit 1
+	"$NODE" "${MALT_ROOT}/share/malt/webview/node_modules/.bin/htpasswd" "$@" || exit 1
 fi
 
 #chmod file

--- a/src/integration/malt-webview.sh.in
+++ b/src/integration/malt-webview.sh.in
@@ -7,6 +7,8 @@
 #            LICENSE  : CeCILL-C                     #
 ######################################################
 
+MALT_ROOT="$(cd $(dirname $0)/.. && pwd)"
+
 ######################################################
 NODE=""
 detectNodeJS()
@@ -50,7 +52,7 @@ if [ ! -f "$HOME/.malt/passwd" ] && [ "$HAVE_NO_AUTH" = "false" ] && [ "$HAVE_CU
 	echo "!!! You need to setup a user/password to secure access to the web GUI !!!"
 	printf "User : "
 	read user
-	"@CMAKE_INSTALL_PREFIX@/bin/malt-passwd" "$user" || exit 1
+	"${MALT_ROOT}/bin/malt-passwd" "$user" || exit 1
 fi
 
 ######################################################
@@ -65,7 +67,7 @@ trap forwardSigterm SIGTERM
 trap forwardSigterm SIGINT
 
 #call node on main script
-"$NODE" "@CMAKE_INSTALL_PREFIX@/share/malt/webview/malt-webserver.js" "$@" &
+"$NODE" "${MALT_ROOT}/share/malt/webview/malt-webserver.js" "$@" &
 CHILD=$!
 wait $!
 exit $?

--- a/src/integration/malt.sh.in
+++ b/src/integration/malt.sh.in
@@ -19,6 +19,7 @@ MALT_OPTIONS=""
 MALT_VERSION="@MALT_VERSION@@MALT_VERSION_NOTE@"
 MALT_ALLOC_WRAPPER=""
 MALT_WRAP_DIR=""
+MALT_ROOT="$(cd $(dirname $0)/.. && pwd)"
 
 ######################################################
 maltCheckArgs()
@@ -256,7 +257,7 @@ maltBuildCustomAllocWrapper()
 		echo "=================================================="
 	fi
 
-	g++ -fPIC -Wall -Werror -shared -I@CMAKE_INSTALL_PREFIX@/include -o ${so_file} ${source_file} || exit 1
+	g++ -fPIC -Wall -Werror -shared -I${MALT_ROOT}/include -o ${so_file} ${source_file} || exit 1
 
 	# export
 	WRAP_SO_FILE="${so_file}"
@@ -307,8 +308,8 @@ maltPrepMPI()
 	fi
 
 	#compile file
-	echo "$mpicxx" '-shared' '-fPIC' "@CMAKE_INSTALL_PREFIX@/share/malt/MaltMPIRank.cpp" -o "$MPI_WRAPPER_DIR/libmaltmpi.so"
-	"$mpicxx" '-shared' '-fPIC' "@CMAKE_INSTALL_PREFIX@/share/malt/MaltMPIRank.cpp" -o "$MPI_WRAPPER_DIR/libmaltmpi.so"
+	echo "$mpicxx" '-shared' '-fPIC' "${MALT_ROOT}/share/malt/MaltMPIRank.cpp" -o "$MPI_WRAPPER_DIR/libmaltmpi.so"
+	"$mpicxx" '-shared' '-fPIC' "${MALT_ROOT}/share/malt/MaltMPIRank.cpp" -o "$MPI_WRAPPER_DIR/libmaltmpi.so"
 	
 	#finish
 	exit $?
@@ -425,9 +426,9 @@ done
 # if [ ! -z "$MALT_CONFIG" ]; then echo "MALT_CONFIG=$MALT_CONFIG"; fi
 
 ######################################################
-MALT_LIB="@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/libmalt.so"
+MALT_LIB="${MALT_ROOT}/@CMAKE_INSTALL_LIBDIR@/libmalt.so"
 if [ ! -f "${MALT_LIB}" ]; then
-	MALT_LIB="@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/libmalt.so"
+	MALT_LIB="${MALT_ROOT}/@CMAKE_INSTALL_LIBDIR@/libmalt.so"
 fi
 
 ######################################################


### PR DESCRIPTION
Because of `@CMAKE_INSTALL_PREFIX@` in `src/integration/*.sh.in`, the installed package is not relocalisable which makes it inconvenient for us to package.

The proposed change has the drawback that the definition of `MALT_ROOT` would need to be changed if the install destination of the scripts is changed but I believe this is an acceptable drawback to get a relocalisable package.