### PR TITLE
[option] Enable by default the output:loop-suppress option (#154)

### DIFF
--- a/doc/source/advanced/options.rst
+++ b/doc/source/advanced/options.rst
@@ -73,7 +73,7 @@ Example of config file :
     config=true            ; dump current config
     verbosity=default      ; malt verbosity level (silent, default, verbose)
     stack-tree=false       ; store the call tree as a tree (smaller file, but need conversion)
-    loop-suppress=false    ; Simplify recursive loop calls to get smaller profile file if too big
+    loop-suppress=true     ; Simplify recursive loop calls to get smaller profile file if too big
     verbosity=default      ; Malt verbosity level (silent, default, verbose).
 	stack-tree=false       ; Store the call tree as a tree (smaller file, but need conversion in the reader);
 
@@ -455,12 +455,12 @@ file from 200 MB to 85 MB. It can help if nodejs failed to load the fail because
 can also provide more readable stacks as you don't care to much how many times you cycle to call loops you
 just want to see one of them.
 
-**Default**: false
+**Default**: true
 
 .. code-block:: shell
 
-    malt -o output:loop-suppress=false ./my_program
     malt -o output:loop-suppress=true ./my_program
+    malt -o output:loop-suppress=false ./my_program
 
 Section `max-stack`
 -------------------

--- a/src/integration/malt.sh.in
+++ b/src/integration/malt.sh.in
@@ -342,15 +342,15 @@ maltSelectProfile()
 	PROFILE_PYTHON_ONLY="python:stack=enter-exit;python:mix=false;stack:mode=python;tools:nm=false;"
 	PROFILE_PYTHON_DOMAINS="python:stack=enter-exit;python:mix=false;stack:mode=backtrace;tools:nm=false;"
 	PROFILE_PYTHON_MIX="python:stack=enter-exit;python:mix=true;stack:mode=backtrace;tools:nm=false;"
-	PROFILE_PYTHON_FULL="python:stack=enter-exit;python:mix=true;stack:mode=backtrace;output:loop-suppress=true;python:hide-imports=false;"
+	PROFILE_PYTHON_FULL="python:stack=enter-exit;python:mix=true;stack:mode=backtrace;python:hide-imports=false;"
 	PROFILE_PYTHON_DEFAULT="${PROFILE_PYTHON_ONLY}"
 	# modes inspirated from scalene configuration (https://arxiv.org/pdf/2212.07597)
-	PROFILE_PYTHON_SAMPLING="python:stack=backtrace;python:mix=true;stack:mode=backtrace;output:loop-suppress=true;sampling:enabled=true;"
-	PROFILE_PYTHON_SAMPLING_10M="python:stack=backtrace;python:mix=true;stack:mode=backtrace;output:loop-suppress=true;sampling:enabled=true;sampling:volume=10485767"
-	PROFILE_PYTHON_SAMPLING_20M="python:stack=backtrace;python:mix=true;stack:mode=backtrace;output:loop-suppress=true;sampling:enabled=true;sampling:volume=20971529"
-	PROFILE_SAMPLING="python:stack=backtrace;stack:mode=backtrace;output:loop-suppress=true;sampling:enabled=true;"
-	PROFILE_SAMPLING_10M="python:stack=backtrace;stack:mode=backtrace;output:loop-suppress=true;sampling:enabled=true;sampling:volume=10485767"
-	PROFILE_SAMPLING_20M="python:stack=backtrace;stack:mode=backtrace;output:loop-suppress=true;sampling:enabled=true;sampling:volume=20971529"
+	PROFILE_PYTHON_SAMPLING="python:stack=backtrace;python:mix=true;stack:mode=backtrace;sampling:enabled=true;"
+	PROFILE_PYTHON_SAMPLING_10M="python:stack=backtrace;python:mix=true;stack:mode=backtrace;sampling:enabled=true;sampling:volume=10485767"
+	PROFILE_PYTHON_SAMPLING_20M="python:stack=backtrace;python:mix=true;stack:mode=backtrace;sampling:enabled=true;sampling:volume=20971529"
+	PROFILE_SAMPLING="python:stack=backtrace;stack:mode=backtrace;sampling:enabled=true;"
+	PROFILE_SAMPLING_10M="python:stack=backtrace;stack:mode=backtrace;sampling:enabled=true;sampling:volume=10485767"
+	PROFILE_SAMPLING_20M="python:stack=backtrace;stack:mode=backtrace;sampling:enabled=true;sampling:volume=20971529"
 	
 
 	# list

--- a/src/libinstrum/common/Options.hpp
+++ b/src/libinstrum/common/Options.hpp
@@ -162,7 +162,7 @@ struct Options
 		bool config{false};
 		Verbosity verbosity{MALT_VERBOSITY_DEFAULT};
 		bool stackTree{false};
-		bool loopSuppress{false};
+		bool loopSuppress{true};
 	} output;
 	//size map
 	struct {

--- a/src/libinstrum/common/tests/TestOptions.cpp
+++ b/src/libinstrum/common/tests/TestOptions.cpp
@@ -61,7 +61,7 @@ const char cstJson[] = "\
 \t\t\"config\":false,\n\
 \t\t\"indent\":false,\n\
 \t\t\"json\":true,\n\
-\t\t\"loop-suppress\":false,\n\
+\t\t\"loop-suppress\":true,\n\
 \t\t\"lua\":false,\n\
 \t\t\"name\":\"malt-%1-%2.%3\",\n\
 \t\t\"stack-tree\":false,\n\

--- a/src/manpages/malt.1.html
+++ b/src/manpages/malt.1.html
@@ -199,7 +199,7 @@ indent                         = true
 config                         = true
 verbosity                      = default
 stack-tree                     = false
-loop-suppress                  = false
+loop-suppress                  = true
 
 [max-stack]
 enabled                        = true

--- a/src/manpages/malt.ronn
+++ b/src/manpages/malt.ronn
@@ -116,7 +116,7 @@ The config file use INI format with sections and variables as in this example :
 	config=true
 	verbosity=default
 	stack-tree=false
-	loop-suppress=false
+	loop-suppress=true
 	verbosity=default
 	stack-tree=false
 

--- a/src/reader/libreader/extractors/tests/example.json
+++ b/src/reader/libreader/extractors/tests/example.json
@@ -52,7 +52,7 @@
 			"config":false,
 			"indent":true,
 			"json":true,
-			"loop-suppress":false,
+			"loop-suppress":true,
 			"lua":false,
 			"name":"src/reader/libreader/extractors/tests/example.json",
 			"stack-tree":false,


### PR DESCRIPTION
Enable by default `-o output:loop-suppress=true` so we don't keep recursivity by default.